### PR TITLE
Fix wrong response from pypi

### DIFF
--- a/gen_spec.py
+++ b/gen_spec.py
@@ -36,7 +36,7 @@ def filter_files(packagename, files):
 
 
 def get_pypi_metadata(packagename):
-    URL = 'http://pypi.python.org/pypi/{}/json'.format(packagename)
+    URL = 'https://pypi.python.org/pypi/{}/json'.format(packagename)
     response = requests.get(URL)
     return response.json()
 


### PR DESCRIPTION
pypi response for HTTP is "SSL required".
So request must be HTTPS.

Just trying workflow :)